### PR TITLE
Allow multiple browser windows

### DIFF
--- a/webview_chromium3.h
+++ b/webview_chromium3.h
@@ -234,6 +234,7 @@ private:
 
     //We also friend ClientHandler so it can access the history
     friend class ClientHandler;
+    CefRefPtr<ClientHandler> m_clientHandler;
   
     wxDECLARE_DYNAMIC_CLASS(wxWebViewChromium);
 };


### PR DESCRIPTION
The client handler cannot be global. Each instance of the browser needs its own client handler as well.

The problem is seen then multiple browser windows is created and used in one application. When loading a url on a specific wxwebview instance the call is forwarded to the global client handler, and this only has a reference to the first browser instance. The call can therefore be send to the wrong chromium instance. 

I also had a small problem with the browserwindow having wrong position. Now I hardcode it to start at position 0,0
